### PR TITLE
🐛️: Fix version string for MONDO

### DIFF
--- a/src/plugins/mondo/version.py
+++ b/src/plugins/mondo/version.py
@@ -5,5 +5,5 @@ def get_release(self):
     for line in doc.iter_lines():
         line = line.decode("utf-8")
         if line.startswith("data-version:"):
-            version = line.split(":")[-1].split("/")[-2]
+            version = line.split(":")[-1].split("/")[-1]
             return version


### PR DESCRIPTION
The function for getting the version was outdated. This change should get the correct string