### PR TITLE
Include obsolete mondo terms

### DIFF
--- a/src/plugins/mondo/mapping.py
+++ b/src/plugins/mondo/mapping.py
@@ -17,6 +17,10 @@ def get_customized_mapping(cls):
                 "comment": {
                     "type": "text"
                 },
+                "consider": {
+                    "type": "keyword",
+                    "normalizer": "keyword_lowercase_normalizer"
+                },
                 "definition": {
                     "type": "text"
                 },
@@ -91,6 +95,9 @@ def get_customized_mapping(cls):
                 "intersection_of": {
                     "type": "text"
                 },
+                'is_obsolete': {
+                    'type': 'boolean'
+                },
                 "label": {
                     "type": "text",
                     "copy_to": [
@@ -131,6 +138,10 @@ def get_customized_mapping(cls):
                             "normalizer": "keyword_lowercase_normalizer"
                         }
                     }
+                },
+                'replaced_by': {
+                    'type': 'keyword',
+                    'normalizer': 'keyword_lowercase_normalizer'
                 },
                 "subset": {
                     "type": "keyword",

--- a/src/plugins/mondo/parser.py
+++ b/src/plugins/mondo/parser.py
@@ -223,10 +223,10 @@ def load_data(data_folder):
         # Handling deprecated terms
         if node_obj.get("is_obsolete", "false") == "true":
             node_doc["is_obsolete"] = True
-            node_doc["replaced_by"] = node_obj.get("replaced_by", None)
+            replaced_by = node_obj.get("replaced_by", None)
+            if replaced_by:
+                node_doc["replaced_by"] = replaced_by[0]
             node_doc["consider"] = node_obj.get("consider", None)
-        else:
-            node_doc["is_obsolete"] = False
 
         node_doc["synonym"] = MondoOntologyHelper.parse_synonyms(node_obj)
         node_doc["xrefs"] = MondoOntologyHelper.parse_xref(node_obj)


### PR DESCRIPTION
Capture `obsolete` Mondo terms and add 3 new properties if a term is `obsolete`:
`is_obsolete` (boolean)
`consider` (used to suggest related or alternative terms when an ontology term is deprecated)
`replaced_by` (indicating that a deprecated ontology term is directly substituted by a newer, more accurate term)

[More information here](https://mondo.readthedocs.io/en/latest/editors-guide/merging-and-obsoleting/)