### PR TITLE
Add MyDiseaseQueryBuilder

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,13 @@
+# .bandit
+skips:
+  - B101
+
+profiles:
+  skips:
+    description: "Skipping assert usage check in test files"
+    include:
+      - "*.py"
+    exclude:
+      - "test_*.py"
+      - "*_test.py"
+      - "**/tests/*.py"

--- a/src/config_web.py
+++ b/src/config_web.py
@@ -1,4 +1,7 @@
+import copy
 import re
+
+from biothings.web.settings.default import QUERY_KWARGS
 
 # *****************************************************************************
 # Elasticsearch variables
@@ -6,6 +9,14 @@ import re
 ES_HOST = "http://localhost:9200"
 ES_ARGS = {"request_timeout": 60}
 ES_INDICES = {"disease": "mydisease_current"}
+
+# *****************************************************************************
+# Elasticsearch Query Pipeline and Customizations
+# *****************************************************************************
+_extra_kwargs = {"ignore_obsolete": {"type": bool, "default": True}}
+QUERY_KWARGS = copy.deepcopy(QUERY_KWARGS)
+QUERY_KWARGS["*"].update(_extra_kwargs)
+ES_QUERY_BUILDER = "web.pipeline.MyDiseaseQueryBuilder"
 
 # *****************************************************************************
 # Web Application

--- a/src/tests/test_remote.py
+++ b/src/tests/test_remote.py
@@ -187,3 +187,20 @@ class TestMyDiseaseConfigDefaultScopes(BiothingsWebTest):
         res = res.json()
         assert len(res) == 1
         assert self.value_in_result(q, res, 'disgenet.xrefs.hp', True)
+
+    # ignore_obsolete parameter
+    def test_ignore_obsolete_true(self):
+        q = 'MONDO:0000006'
+        res = self.request("query", method="POST",
+                           data={"q": q, "ignore_obsolete": True})
+        res = res.json()
+        assert len(res) == 1
+        assert res[0]['notfound'] is True
+
+    def test_ignore_obsolete_false(self):
+        q = 'MONDO:0000006'
+        res = self.request("query", method="POST",
+                           data={"q": q, "ignore_obsolete": False})
+        res = res.json()
+        assert len(res) == 1
+        assert res[0]['_id'] == q

--- a/src/web/pipeline.py
+++ b/src/web/pipeline.py
@@ -1,0 +1,10 @@
+from biothings.web.query import ESQueryBuilder
+from elasticsearch_dsl import Q
+
+
+class MyDiseaseQueryBuilder(ESQueryBuilder):
+    def apply_extras(self, search, options):
+        if options.ignore_obsolete:
+            # Filter out obsolete terms (mondo.is_obsolete=True)
+            search = search.filter(~Q("term", **{"mondo.is_obsolete": True}))
+        return super().apply_extras(search, options)


### PR DESCRIPTION
Add a new parameter to the `query` endpoint: `ignore_obsolete`. By default it is set to `True`, ignoring all mondo terms that are obsolete (`mondo.is_obsolete`). If set to `False` these terms will be displayed. Works on `POST` and `GET`.